### PR TITLE
add build dependencies to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ MinSQL is a log search engine designed with simplicity in mind to the extent tha
 
 ## To build
 
+### Build dependencies:
+
+Make sure you have installed
+ - `OpenSSL`:
+    - Debian/Ubuntu: `sudo apt install libssl-dev`
+    - RedHat/Fedora: `sudo dnf install openssl-devel`
+ - `pkg-config`:
+    - Debian/Ubuntu: `sudo apt install pkg-config`
+    - RedHat/Fedora: `sudo dnf install pkgconfig`
+ - `hyperscan-dev`:  
+    - Debian/Ubuntu: `sudo apt install libhyperscan-dev`
+    - RedHat/Fedora: `sudo dnf install hyperscan`
+
 To build the project simply run 
 ```bash
 cargo build --release


### PR DESCRIPTION
This commit adds the build dependencies
for Debian/Ubuntu and RedHat/Fedora systems
to the README - since running just `cargo build`
does not work on its own.

It does not add any build dependency information
for MacOS or Windows systems (or other linux distros).
In particular, a Mac user should try to do a fresh
clone and `cargo build` and add any missing dependencies
to the README.