### PR TITLE
Read multiple Datastores concurrently for queries

### DIFF
--- a/src/combinators/mod.rs
+++ b/src/combinators/mod.rs
@@ -1,0 +1,16 @@
+// This file is part of MinSQL
+// Copyright (c) 2019 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+pub mod take_from_iterable;

--- a/src/combinators/take_from_iterable.rs
+++ b/src/combinators/take_from_iterable.rs
@@ -1,3 +1,18 @@
+// This file is part of MinSQL
+// Copyright (c) 2019 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 use futures::{stream, StartSend};
 use std::ops::Deref;
 use tokio::prelude::{Async, Poll, Sink, Stream};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ mod dialect;
 mod filter;
 mod http;
 mod ingest;
+mod line_taker;
 mod meta;
 mod query;
 mod storage;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,13 +37,13 @@ use crate::ingest::{Ingest, IngestBuffer};
 use crate::meta::Meta;
 
 mod auth;
+mod combinators;
 mod config;
 mod constants;
 mod dialect;
 mod filter;
 mod http;
 mod ingest;
-mod line_taker;
 mod meta;
 mod query;
 mod storage;

--- a/src/line_taker.rs
+++ b/src/line_taker.rs
@@ -17,9 +17,8 @@ pub fn take_lines<S: Stream>(stream: S, amt: u64) -> LineTaker<S> {
     self::new(stream, amt)
 }
 
-/// A stream combinator which returns a maximum number of elements.
-///
-/// This structure is produced by the `Stream::LineTaker` method.
+/// A stream combinator which returns a maximum number of elements across multiple batches of
+/// elements.
 #[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct LineTaker<S> {

--- a/src/line_taker.rs
+++ b/src/line_taker.rs
@@ -13,17 +13,17 @@ macro_rules! try_ready {
     };
 }
 
-pub trait TakeLines {
-    fn take_lines(self, amt: u64) -> LineTaker<Self>
+pub trait TakeFromIterable {
+    fn take_from_iterable(self, amt: u64) -> IterableTaker<Self>
     where
         Self: Sized;
 }
 
-impl<S: Stream, F, U> TakeLines for stream::Map<S, F>
+impl<S: Stream, F, U> TakeFromIterable for stream::Map<S, F>
 where
     F: FnMut(S::Item) -> U,
 {
-    fn take_lines(self, amt: u64) -> LineTaker<Self>
+    fn take_from_iterable(self, amt: u64) -> IterableTaker<Self>
     where
         Self: Sized,
     {
@@ -35,23 +35,23 @@ where
 /// elements.
 #[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
-pub struct LineTaker<S> {
+pub struct IterableTaker<S> {
     stream: S,
     remaining: u64,
 }
 
-pub fn new<S>(s: S, amt: u64) -> LineTaker<S>
+pub fn new<S>(s: S, amt: u64) -> IterableTaker<S>
 where
     S: Stream,
 {
-    LineTaker {
+    IterableTaker {
         stream: s,
         remaining: amt,
     }
 }
 
 // Forwarding impl of Sink from the underlying stream
-impl<S> Sink for LineTaker<S>
+impl<S> Sink for IterableTaker<S>
 where
     S: Sink + Stream,
 {
@@ -71,7 +71,7 @@ where
     }
 }
 
-impl<S, T> Stream for LineTaker<S>
+impl<S, T> Stream for IterableTaker<S>
 where
     S: Stream,
     S::Item: Deref<Target = [T]>,

--- a/src/line_taker.rs
+++ b/src/line_taker.rs
@@ -1,0 +1,100 @@
+use futures::StartSend;
+use std::ops::Deref;
+use tokio::prelude::{Async, Poll, Sink, Stream};
+
+#[macro_export]
+macro_rules! try_ready {
+    ($e:expr) => {
+        match $e {
+            Ok(tokio::prelude::Async::Ready(t)) => t,
+            Ok(tokio::prelude::Async::NotReady) => return Ok(tokio::prelude::Async::NotReady),
+            Err(e) => return Err(From::from(e)),
+        }
+    };
+}
+
+pub fn take_lines<S: Stream>(stream: S, amt: u64) -> LineTaker<S> {
+    self::new(stream, amt)
+}
+
+/// A stream combinator which returns a maximum number of elements.
+///
+/// This structure is produced by the `Stream::LineTaker` method.
+#[derive(Debug)]
+#[must_use = "streams do nothing unless polled"]
+pub struct LineTaker<S> {
+    stream: S,
+    remaining: u64,
+}
+
+pub fn new<S>(s: S, amt: u64) -> LineTaker<S>
+where
+    S: Stream,
+{
+    LineTaker {
+        stream: s,
+        remaining: amt,
+    }
+}
+
+// Forwarding impl of Sink from the underlying stream
+impl<S> Sink for LineTaker<S>
+where
+    S: Sink + Stream,
+{
+    type SinkItem = S::SinkItem;
+    type SinkError = S::SinkError;
+
+    fn start_send(&mut self, item: S::SinkItem) -> StartSend<S::SinkItem, S::SinkError> {
+        self.stream.start_send(item)
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.poll_complete()
+    }
+
+    fn close(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.close()
+    }
+}
+
+impl<S, T> Stream for LineTaker<S>
+where
+    S: Stream,
+    S::Item: Deref<Target = [T]>,
+    S::Item: std::iter::FromIterator<T>,
+    S::Item: std::iter::IntoIterator,
+    T: std::clone::Clone,
+    <S as futures::stream::Stream>::Item: std::iter::FromIterator<
+        <<S as futures::stream::Stream>::Item as std::iter::IntoIterator>::Item,
+    >,
+{
+    type Item = S::Item;
+    type Error = S::Error;
+
+    fn poll(&mut self) -> Poll<Option<S::Item>, S::Error> {
+        if self.remaining <= 0 {
+            Ok(Async::Ready(None))
+        } else {
+            let next = try_ready!(self.stream.poll());
+            match next {
+                Some(v) => {
+                    let len = v.len() as u64;
+                    if self.remaining.checked_sub(len) == None {
+                        let new_vec: S::Item =
+                            v.into_iter().take(self.remaining as usize).collect();
+                        self.remaining = 0;
+                        return Ok(Async::Ready(Some(new_vec)));
+                    } else {
+                        self.remaining -= v.len() as u64;
+                        return Ok(Async::Ready(Some(v)));
+                    }
+                }
+                None => {
+                    self.remaining = 0;
+                    return Ok(Async::Ready(next));
+                }
+            }
+        }
+    }
+}

--- a/src/query.rs
+++ b/src/query.rs
@@ -34,6 +34,7 @@ use bitflags::bitflags;
 use lazy_static::lazy_static;
 
 use crate::auth::Auth;
+use crate::combinators::take_from_iterable::TakeFromIterable;
 use crate::config::Config;
 use crate::constants::SF_DATE;
 use crate::constants::SF_EMAIL;
@@ -45,7 +46,6 @@ use crate::filter::line_fails_query_conditions;
 use crate::http::GenericError;
 use crate::http::ResponseFuture;
 use crate::http::{return_400, return_401};
-use crate::line_taker::TakeFromIterable;
 use crate::storage::{list_msl_bucket_files, read_file_line_by_line};
 
 bitflags! {

--- a/src/query.rs
+++ b/src/query.rs
@@ -258,61 +258,21 @@ impl Query {
                             // For each datastore in the log we are going to spawn a task to read the
                             // logs stored in given datastore.
                             for i in 0..logs_ds_len {
-                                let cfg = Arc::clone(&cfg);
-                                let query_state_holder = Arc::clone(&query_state_holder);
+                                let cfg2 = Arc::clone(&cfg);
+                                let query_state_holder2 = Arc::clone(&query_state_holder);
                                 let tx = tx.clone();
                                 // Task that will read all the logs for a given datastore
                                 let task = stream::iter_ok(i..i + 1)
                                     .map(move |log_ds_index| {
-                                        let cfg_read = cfg.read().unwrap();
-                                        let read_state_holder = query_state_holder.read().unwrap();
-
-                                        let q_parse =
-                                            &read_state_holder.query_parsing[query_index].1;
-                                        let log = cfg_read.get_log(&q_parse.log_name).unwrap();
-
-                                        let ds_name = &log.datastores[log_ds_index];
-
-                                        let log_name = cfg
-                                            .read()
-                                            .unwrap()
-                                            .get_log(&q_parse.log_name)
-                                            .unwrap()
-                                            .name
-                                            .clone()
-                                            .unwrap();
-                                        // validation should make this unwrapping safe
-                                        let ds = cfg_read.datastore.get(ds_name.as_str()).unwrap();
-
-                                        let cfg2 = Arc::clone(&cfg);
-                                        let query_state_holder2 = Arc::clone(&query_state_holder);
-
-                                        // Returns Result<(ds, files), error>. Need to stop on error.
-                                        // TODO: Stop on error
-                                        list_msl_bucket_files(log_name.as_str(), &ds)
-                                            .map(move |obj_key| {
-                                                (query_index.clone(), log_ds_index.clone(), obj_key)
-                                            })
-                                            .map_err(|e| QueryError::Underlying(format!("{:?}", e))) //temporarely remove error, we need to adress this
-                                            .map(move |(query_index, log_ds_index, obj_key)| {
-                                                // TODO: Limit the number of results
-                                                let read_state_holder =
-                                                    query_state_holder2.read().unwrap();
-                                                let q_parse =
-                                                    &read_state_holder.query_parsing[query_index].1;
-
-                                                let cfg_read = cfg2.read().unwrap();
-                                                let log =
-                                                    cfg_read.get_log(&q_parse.log_name).unwrap();
-
-                                                let ds_name = &log.datastores[log_ds_index];
-                                                let ds = cfg_read.datastore.get(ds_name).unwrap();
-
-                                                read_file_line_by_line(&obj_key, &ds).map_err(|e| {
-                                                    QueryError::Underlying(format!("{:?}", e))
-                                                })
-                                            })
-                                            .flatten()
+                                        let cfg2 = Arc::clone(&cfg2);
+                                        let query_state_holder2 = Arc::clone(&query_state_holder2);
+                                        // let log_ds_index = log_ds_index.clone();
+                                        Query::read_logs_from_datastore(
+                                            cfg2,
+                                            query_state_holder2,
+                                            query_index,
+                                            log_ds_index,
+                                        )
                                     })
                                     .flatten()
                                     .fold(tx, |tx, lines| {
@@ -554,6 +514,55 @@ impl Query {
         ast.into_iter()
             .map(|q| self.process_statement(&access_token, q))
             .collect()
+    }
+
+    /// Reads all the log files for a given `QueryParse` in marked `DataSource`
+    fn read_logs_from_datastore(
+        cfg: Arc<RwLock<Config>>,
+        query_state_holder: Arc<RwLock<StateHolder>>,
+        query_index: usize,
+        log_ds_index: usize,
+    ) -> impl Stream<Item = Vec<String>, Error = QueryError> {
+        let cfg_read = cfg.read().unwrap();
+        let read_state_holder = query_state_holder.read().unwrap();
+
+        // Get the `QueryParse` and the `Log` from the indexes provided
+        let q_parse = &read_state_holder.query_parsing[query_index].1;
+        let log = cfg_read.get_log(&q_parse.log_name).unwrap();
+
+        let ds_name = &log.datastores[log_ds_index];
+
+        let log_name = cfg
+            .read()
+            .unwrap()
+            .get_log(&q_parse.log_name)
+            .unwrap()
+            .name
+            .clone()
+            .unwrap();
+        // validation should make this unwrapping safe
+        let ds = cfg_read.datastore.get(ds_name.as_str()).unwrap();
+        let cfg2 = Arc::clone(&cfg);
+        let query_state_holder2 = Arc::clone(&query_state_holder);
+        // Returns Result<(ds, files), error>. Need to stop on error.
+        // TODO: Stop on error
+        list_msl_bucket_files(log_name.as_str(), &ds)
+            .map(move |obj_key| (query_index.clone(), log_ds_index.clone(), obj_key))
+            .map_err(|e| QueryError::Underlying(format!("{:?}", e))) //temporarely remove error, we need to adress this
+            .map(move |(query_index, log_ds_index, obj_key)| {
+                let read_state_holder = query_state_holder2.read().unwrap();
+                let q_parse = &read_state_holder.query_parsing[query_index].1;
+
+                let cfg_read = cfg2.read().unwrap();
+                let log = cfg_read.get_log(&q_parse.log_name).unwrap();
+
+                let ds_name = &log.datastores[log_ds_index];
+                let ds = cfg_read.datastore.get(ds_name).unwrap();
+
+                read_file_line_by_line(&obj_key, &ds)
+                    .map_err(|e| QueryError::Underlying(format!("{:?}", e)))
+            })
+            .flatten()
     }
 }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -45,7 +45,7 @@ use crate::filter::line_fails_query_conditions;
 use crate::http::GenericError;
 use crate::http::ResponseFuture;
 use crate::http::{return_400, return_401};
-use crate::line_taker::TakeLines;
+use crate::line_taker::TakeFromIterable;
 use crate::storage::{list_msl_bucket_files, read_file_line_by_line};
 
 bitflags! {
@@ -298,7 +298,7 @@ impl Query {
                                         })
                                         .collect::<Vec<String>>()
                                 })
-                                .take_lines(limit)
+                                .take_from_iterable(limit)
                         })
                         .flatten()
                         .map(|s: Vec<String>| Chunk::from(s.join("\n") + &"\n"));

--- a/src/query.rs
+++ b/src/query.rs
@@ -255,14 +255,11 @@ impl Query {
 
                             let (tx, rx) = mpsc::unbounded_channel();
 
-                            println!("total ds {}", &logs_ds_len);
-
                             for i in 0..logs_ds_len {
                                 let cfg = Arc::clone(&cfg);
                                 let query_state_holder = Arc::clone(&query_state_holder);
                                 let tx = tx.clone();
 
-                                println!("produce stream {}", &i);
                                 let task = stream::iter_ok(i..i + 1)
                                     .map(move |log_ds_index| {
                                         let cfg_read = cfg.read().unwrap();
@@ -273,7 +270,6 @@ impl Query {
                                         let log = cfg_read.get_log(&q_parse.log_name).unwrap();
 
                                         let ds_name = &log.datastores[log_ds_index];
-                                        println!("processing {}", &ds_name);
 
                                         let log_name = cfg
                                             .read()

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -279,7 +279,7 @@ pub enum GetObjectError {
 pub fn read_file_line_by_line(
     key: &String,
     datastore: &DataStore,
-) -> impl Stream<Item = String, Error = StorageError<GetObjectError>> {
+) -> impl Stream<Item = Vec<String>, Error = StorageError<GetObjectError>> {
     let s3_client = client_for_datastore(datastore);
     s3_client
         .get_object(GetObjectRequest {
@@ -299,6 +299,7 @@ pub fn read_file_line_by_line(
                 // max line length of 1MiB
                 LinesCodec::new_with_max_length(1024 * 1024),
             )
+            .chunks(4096)
             .map_err(|e| StorageError::Operation(GetObjectError::IOError(format!("{:?}", e))))
         })
         .flatten_stream()


### PR DESCRIPTION
This PR introduces an `mpsc` to allow reading from all datastores in a log concurrently