### PR TITLE
Support new entities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,6 +664,7 @@ dependencies = [
  "tokio-tls 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "woothee 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1788,6 +1789,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "woothee"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2014,6 +2024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
+"checksum woothee 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e0743ef75769346589559a512f388a0166f93e9432ab93707e99ac42d4d8ae52"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"
 "checksum xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "541b12c998c5b56aa2b4e6f18f03664eef9a4fd0a246a55594efae6cc2d964b5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,5 @@ tokio-io = "0.1.12"
 tokio-tls = "0.2.1"
 url = "1.7.2"
 uuid = { version = "0.7.4", features = ["v4"] }
+woothee = "0.10.0"
 xml-rs = "0.8.0"

--- a/README.md
+++ b/README.md
@@ -273,3 +273,14 @@ A list of supported entities by MinSQL :
 * *$email*: Any email@address.com
 * *$quoted*: any text that is within single quotes (') or double quotes (")
 * *$url*: any url starting with http
+* *$phone*: any valid 10 digit phone.
+* *$user_agent*: A quoted user agent found in the logs
+  * *$user_agent.name*: Browser name
+  * *$user_agent.category*: type of machine (pc, mac)
+  * *$user_agent.os*: Operative System name
+  * *$user_agent.os_version*: Operative System version
+  * *$user_agent.browser_type*: Type of browser
+  * *$user_agent.version*: version of browser
+  * *$user_agent.vendor*: browser vendor
+
+

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -23,3 +23,8 @@ pub const SF_EMAIL: &str = "$email";
 pub const SF_DATE: &str = "$date";
 pub const SF_QUOTED: &str = "$quoted";
 pub const SF_URL: &str = "$url";
+pub const SF_PHONE: &str = "$phone";
+pub const SF_USER_AGENT: &str = "$user_agent";
+
+pub const SMART_FIELDS_RAW_RE: &str =
+    r"((\$(ip|email|date|url|quoted|phone|user_agent))([0-9]+)*)\b";

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -227,10 +227,10 @@ pub fn evaluate(
 
 /// Extracts an `Expr` identifier as a `String`
 pub fn get_identifier_from_ast(ast: &Expr) -> Option<String> {
-    if let Expr::Identifier(ref id) = ast {
-        Some(id.to_string())
-    } else {
-        None
+    match ast {
+        Expr::Identifier(ref id) => Some(id.to_string()),
+        Expr::CompoundIdentifier(ref id) => Some(id.join(".")),
+        _ => None,
     }
 }
 
@@ -326,6 +326,13 @@ mod filter_tests {
         let ast_node = Expr::Identifier("test_id".to_owned());
         let identifier = get_identifier_from_ast(&ast_node);
         assert_eq!(identifier, Some("test_id".to_string()));
+    }
+
+    #[test]
+    fn get_identifier_from_ast_node_compount() {
+        let ast_node = Expr::CompoundIdentifier(vec!["test_id".to_owned(), "subfield".to_owned()]);
+        let identifier = get_identifier_from_ast(&ast_node);
+        assert_eq!(identifier, Some("test_id.subfield".to_string()));
     }
 
     #[test]

--- a/src/query.rs
+++ b/src/query.rs
@@ -65,6 +65,14 @@ bitflags! {
 }
 
 lazy_static! {
+    static ref IP_RE :Regex= Regex::new(r"(((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9]))").unwrap();
+    static ref EMAIL_RE :Regex= Regex::new(r"([\w\.!#$%&'*+\-=?\^_`{|}~]+@([\w\d-]+\.)+[\w]{2,4})").unwrap();
+    // TODO: This regex matches a fairly simple date format, improve : 2019-05-23
+    static ref DATE_RE :Regex= Regex::new(r"((19[789]\d|2\d{3})[-/](0[1-9]|1[1-2])[-/](0[1-9]|[1-2][0-9]|3[0-1]*))|((0[1-9]|[1-2][0-9]|3[0-1]*)[-/](Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|(0[1-9]|1[1-2]))[-/](19[789]\d|2\d{3}))").unwrap();
+    static ref QUOTED_RE :Regex= Regex::new("((\"(.*?)\")|'(.*?)')").unwrap();
+    static ref URL_RE :Regex= Regex::new(r#"(https?|ftp)://[^\s/$.?#].[^()\]\[\s]*"#).unwrap();
+    static ref PHONE_RE :Regex= Regex::new(r#"[\(]?(\d{3})[\)-]?[- ]?(\d{3})[- ]?(\d{4})"#).unwrap();
+    static ref USER_AGENT_RE :Regex= Regex::new(r#""((Mozilla|Links).*? \(.*?\)( .*?[0-9]{1,3}\.[0-9]{1,3}\.?[0-9]{0,3})?)""#).unwrap();
     static ref SMART_FIELDS_RE: Regex = Regex::new(SMART_FIELDS_RAW_RE).unwrap();
 }
 
@@ -651,17 +659,6 @@ fn process_fields_for_ast(
 }
 
 pub fn scanlog(text: &String, flags: ScanFlags) -> HashMap<String, Vec<String>> {
-    // Compile the regex only once
-    lazy_static! {
-        static ref IP_RE :Regex= Regex::new(r"(((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9]))").unwrap();
-        static ref EMAIL_RE :Regex= Regex::new(r"([\w\.!#$%&'*+\-=?\^_`{|}~]+@([\w\d-]+\.)+[\w]{2,4})").unwrap();
-        // TODO: This regex matches a fairly simple date format, improve : 2019-05-23
-        static ref DATE_RE :Regex= Regex::new(r"((19[789]\d|2\d{3})[-/](0[1-9]|1[1-2])[-/](0[1-9]|[1-2][0-9]|3[0-1]*))|((0[1-9]|[1-2][0-9]|3[0-1]*)[-/](Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|(0[1-9]|1[1-2]))[-/](19[789]\d|2\d{3}))").unwrap();
-        static ref QUOTED_RE :Regex= Regex::new("((\"(.*?)\")|'(.*?)')").unwrap();
-        static ref URL_RE :Regex= Regex::new(r#"(https?|ftp)://[^\s/$.?#].[^()\]\[\s]*"#).unwrap();
-        static ref PHONE_RE :Regex= Regex::new(r#"[\(]?(\d{3})[\)-]?[- ]?(\d{3})[- ]?(\d{4})"#).unwrap();
-        static ref USER_AGENT_RE :Regex= Regex::new(r#""((Mozilla|Links).*? \(.*?\)( .*?[0-9]{1,3}\.[0-9]{1,3}\.?[0-9]{0,3})?)""#).unwrap();
-    }
     let mut results: HashMap<String, Vec<String>> = HashMap::new();
 
     if flags.contains(ScanFlags::IP) {

--- a/src/query.rs
+++ b/src/query.rs
@@ -26,6 +26,7 @@ use futures::{stream, Future, Stream};
 use hyper::{Body, Chunk, Request, Response};
 use log::{error, info};
 use regex::Regex;
+use serde_json::json;
 use sqlparser::ast::{BinaryOperator, Expr, SelectItem, SetExpr, Statement, Value};
 use sqlparser::parser::Parser;
 use sqlparser::parser::ParserError;
@@ -33,16 +34,13 @@ use tokio::sync::mpsc;
 
 use bitflags::bitflags;
 use lazy_static::lazy_static;
-use serde_json::json;
 
 use crate::auth::Auth;
 use crate::combinators::take_from_iterable::TakeFromIterable;
 use crate::config::Config;
-use crate::constants::SF_DATE;
-use crate::constants::SF_EMAIL;
-use crate::constants::SF_IP;
-use crate::constants::SF_QUOTED;
-use crate::constants::SF_URL;
+use crate::constants::{
+    SF_DATE, SF_EMAIL, SF_IP, SF_PHONE, SF_QUOTED, SF_URL, SF_USER_AGENT, SMART_FIELDS_RAW_RE,
+};
 use crate::dialect::MinSQLDialect;
 use crate::filter::line_fails_query_conditions;
 use crate::http::GenericError;
@@ -55,12 +53,14 @@ bitflags! {
     // If you are adding new values make sure to add the next power of 2 as
     // they are evaluated using a bitwise operation
     pub struct ScanFlags: u32 {
-        const IP = 1;
-        const EMAIL = 2;
-        const DATE = 4;
-        const QUOTED = 8;
-        const URL = 16;
-        const NONE = 32;
+        const NONE = 1;
+        const IP = 2;
+        const EMAIL = 4;
+        const DATE = 8;
+        const QUOTED = 16;
+        const URL = 32;
+        const PHONE = 64;
+        const USER_AGENT = 128;
     }
 }
 
@@ -78,6 +78,8 @@ struct SmartColumn {
     position: i32,
     // if this column was aliased
     alias: String,
+    // if the smart field has subfields `$ip.country`
+    subfield: Option<String>,
 }
 
 #[derive(Debug)]
@@ -157,7 +159,13 @@ impl Query {
             let some_table = match query {
                 Statement::Query(q) => match q.body {
                     // TODO: Validate a single table
-                    SetExpr::Select(ref bodyselect) => Some(bodyselect.from[0].relation.clone()),
+                    SetExpr::Select(ref bodyselect) => {
+                        if bodyselect.from.len() == 0 {
+                            None
+                        } else {
+                            Some(bodyselect.from[0].relation.clone())
+                        }
+                    }
                     _ => None,
                 },
                 _ => {
@@ -333,8 +341,7 @@ impl Query {
         query: Statement,
     ) -> Result<(Statement, QueryParsing), ProcessingQueryError> {
         lazy_static! {
-            static ref SMART_FIELDS_RE: Regex =
-                Regex::new(r"((\$(ip|email|date|url|quoted))([0-9]+)*)\b").unwrap();
+            static ref SMART_FIELDS_RE: Regex = Regex::new(SMART_FIELDS_RAW_RE).unwrap();
         };
         // find the table they want to query
         let some_table = match query {
@@ -406,7 +413,6 @@ impl Query {
         let mut smart_fields: Vec<SmartColumn> = Vec::new();
         let mut smart_fields_set: HashSet<String> = HashSet::new();
         let mut projections_ordered: Vec<String> = Vec::new();
-        // TODO: We should stream the data out as it becomes available to save memory
         for proj in &projections {
             match proj {
                 SelectItem::UnnamedExpr(ref ast) => {
@@ -414,10 +420,7 @@ impl Query {
                     match ast {
                         Expr::Identifier(ref identifier) => {
                             let id_name = &identifier[1..];
-                            let position = match id_name.parse::<i32>() {
-                                Ok(p) => p,
-                                Err(_) => -1,
-                            };
+                            let position = id_name.parse::<i32>().unwrap_or(-1);
                             // if we were able to parse identifier as an i32 it's a positional
                             if position > 0 {
                                 positional_fields.push(PositionalColumn {
@@ -427,16 +430,12 @@ impl Query {
                                 projections_ordered.push(identifier.clone());
                             } else {
                                 // try to parse as as smart field
-                                for sfield in SMART_FIELDS_RE.captures_iter(identifier) {
-                                    let typed = sfield[2].to_string();
-                                    let mut pos = 1;
-                                    if sfield.get(4).is_none() == false {
-                                        pos = match sfield[4].parse::<i32>() {
-                                            Ok(p) => p,
-                                            // technically this should never happen as the regex already validated an integer
-                                            Err(_) => -1,
-                                        };
-                                    }
+                                for smart_field_match in SMART_FIELDS_RE.captures_iter(identifier) {
+                                    let typed = smart_field_match[2].to_string();
+                                    // Default the position to 1 unless there's a matching group for position
+                                    let pos = smart_field_match
+                                        .get(4)
+                                        .map_or(1, |m| m.as_str().parse::<i32>().unwrap_or(1));
                                     // we use this set to keep track of active smart fields
                                     smart_fields_set.insert(typed.clone());
                                     // track the smartfield
@@ -444,13 +443,47 @@ impl Query {
                                         typed: typed.clone(),
                                         position: pos,
                                         alias: identifier.clone(),
+                                        subfield: None,
                                     });
                                     // record the order or extraction
                                     projections_ordered.push(identifier.clone());
                                 }
                             }
                         }
-                        _ => (),
+                        Expr::CompoundIdentifier(ref identifier) => {
+                            let id_name = &identifier[0][1..];
+                            let position = id_name.parse::<i32>().unwrap_or(-1);
+                            // We don't do compound identifiers on positional arguments, only smart
+                            // fields
+                            if position < 0 {
+                                // try to parse as as smart field
+                                for smart_field_match in
+                                    SMART_FIELDS_RE.captures_iter(&identifier[0][..])
+                                {
+                                    let typed = smart_field_match[2].to_string();
+                                    // Default the position to 1 unless there's a matching group for position
+                                    let pos = smart_field_match
+                                        .get(4)
+                                        .map_or(1, |m| m.as_str().parse::<i32>().unwrap_or(1));
+                                    // get subfield
+                                    let subfield = Some(identifier[1..].join("."));
+                                    // we use this set to keep track of active smart fields
+                                    smart_fields_set.insert(typed.clone());
+                                    // track the smartfield
+                                    smart_fields.push(SmartColumn {
+                                        typed: typed.clone(),
+                                        position: pos,
+                                        alias: identifier.join(".").clone(),
+                                        subfield: subfield,
+                                    });
+                                    // record the order or extraction
+                                    projections_ordered.push(identifier.join("."));
+                                }
+                            }
+                        }
+                        x => {
+                            info!("Use un unhandled ast {:?}", &x);
+                        }
                     }
                 }
                 _ => {} // for now let's not do anything on other Variances
@@ -496,6 +529,8 @@ impl Query {
                 "$date" => ScanFlags::DATE,
                 "$quoted" => ScanFlags::QUOTED,
                 "$url" => ScanFlags::URL,
+                "$phone" => ScanFlags::PHONE,
+                "$user_agent" => ScanFlags::USER_AGENT,
                 _ => ScanFlags::NONE,
             };
             if scan_flags == ScanFlags::NONE {
@@ -589,8 +624,7 @@ fn process_fields_for_ast(
     smart_fields_set: &mut HashSet<String>,
 ) {
     lazy_static! {
-        static ref SMART_FIELDS_RE: Regex =
-            Regex::new(r"((\$(ip|email|date|url|quoted))([0-9]+)*)\b").unwrap();
+        static ref SMART_FIELDS_RE: Regex = Regex::new(SMART_FIELDS_RAW_RE).unwrap();
     };
     match ast_node {
         Expr::Nested(nested_ast) => {
@@ -602,88 +636,134 @@ fn process_fields_for_ast(
             );
         }
         Expr::IsNotNull(ast) => {
-            let identifier = match **ast {
-                Expr::Identifier(ref identifier) => identifier.to_string(),
-                _ => {
-                    // TODO: Should we be retunring anything at all?
-                    "".to_string()
-                }
-            };
-            //positional or smart?
-            let id_name = &identifier[1..];
-            let position = match id_name.parse::<i32>() {
-                Ok(p) => p,
-                Err(_) => -1,
-            };
-            // if we were able to parse identifier as an i32 it's a positional
-            if position > 0 {
-                positional_fields.push(PositionalColumn {
-                    position: position,
-                    alias: identifier.clone(),
-                });
-            } else {
-                // try to parse as as smart field
-                for sfield in SMART_FIELDS_RE.captures_iter(&identifier[..]) {
-                    let typed = sfield[2].to_string();
-                    let mut pos = 1;
-                    if sfield.get(4).is_none() == false {
-                        pos = match sfield[4].parse::<i32>() {
-                            Ok(p) => p,
-                            // technically this should never happen as the regex already validated an integer
-                            Err(_) => -1,
-                        };
+            match **ast {
+                Expr::Identifier(ref identifier) => {
+                    //positional or smart?
+                    let id_name = &identifier[1..];
+                    let position = id_name.parse::<i32>().unwrap_or(-1);
+                    // if we were able to parse identifier as an i32 it's a positional
+                    if position > 0 {
+                        positional_fields.push(PositionalColumn {
+                            position: position,
+                            alias: identifier.clone(),
+                        });
+                    } else {
+                        // try to parse as as smart field
+                        for smart_field_match in SMART_FIELDS_RE.captures_iter(&identifier[..]) {
+                            let typed = smart_field_match[2].to_string();
+                            // Default the position to 1 unless there's a matching group for position
+                            let pos = smart_field_match
+                                .get(4)
+                                .map_or(1, |m| m.as_str().parse::<i32>().unwrap_or(1));
+                            // we use this set to keep track of active smart fields
+                            smart_fields_set.insert(typed.clone());
+                            // track the smartfield
+                            smart_fields.push(SmartColumn {
+                                typed: typed.clone(),
+                                position: pos,
+                                alias: identifier.clone(),
+                                subfield: None,
+                            });
+                        }
                     }
-                    // we use this set to keep track of active smart fields
-                    smart_fields_set.insert(typed.clone());
-                    // track the smartfield
-                    smart_fields.push(SmartColumn {
-                        typed: typed.clone(),
-                        position: pos,
-                        alias: identifier.clone(),
-                    });
+                }
+                Expr::CompoundIdentifier(ref identifier) => {
+                    //positional or smart?
+                    let id_name = &identifier[0][1..];
+                    let position = id_name.parse::<i32>().unwrap_or(-1);
+                    // no positions for compound identifiers
+                    if position < 0 {
+                        // try to parse as as smart field
+                        for smart_field_match in SMART_FIELDS_RE.captures_iter(&identifier[0][..]) {
+                            let typed = smart_field_match[2].to_string();
+                            // Default the position to 1 unless there's a matching group for position
+                            let pos = smart_field_match
+                                .get(4)
+                                .map_or(1, |m| m.as_str().parse::<i32>().unwrap_or(1));
+                            // get subfield
+                            let subfield = Some(identifier[1..].join("."));
+                            // we use this set to keep track of active smart fields
+                            smart_fields_set.insert(typed.clone());
+                            // track the smartfield
+                            smart_fields.push(SmartColumn {
+                                typed: typed.clone(),
+                                position: pos,
+                                alias: identifier.join(".").clone(),
+                                subfield: subfield,
+                            });
+                        }
+                    }
+                }
+                ref x => {
+                    info!("Use un unhandled ast {:?}", x);
                 }
             }
         }
         Expr::IsNull(ast) => {
-            let identifier = match **ast {
-                Expr::Identifier(ref identifier) => identifier.to_string(),
-                _ => {
-                    // TODO: Should we be retunring anything at all?
-                    "".to_string()
-                }
-            };
-            //positional or smart?
-            let id_name = &identifier[1..];
-            let position = match id_name.parse::<i32>() {
-                Ok(p) => p,
-                Err(_) => -1,
-            };
-            // if we were able to parse identifier as an i32 it's a positional
-            if position > 0 {
-                positional_fields.push(PositionalColumn {
-                    position: position,
-                    alias: identifier.clone(),
-                });
-            } else {
-                // try to parse as as smart field
-                for sfield in SMART_FIELDS_RE.captures_iter(&identifier[..]) {
-                    let typed = sfield[2].to_string();
-                    let mut pos = 1;
-                    if sfield.get(4).is_none() == false {
-                        pos = match sfield[4].parse::<i32>() {
-                            Ok(p) => p,
-                            // technically this should never happen as the regex already validated an integer
-                            Err(_) => -1,
-                        };
+            match **ast {
+                Expr::Identifier(ref identifier) => {
+                    //positional or smart?
+                    let id_name = &identifier[1..];
+                    let position = id_name.parse::<i32>().unwrap_or(-1);
+                    // if we were able to parse identifier as an i32 it's a positional
+                    if position > 0 {
+                        positional_fields.push(PositionalColumn {
+                            position: position,
+                            alias: identifier.clone(),
+                        });
+                    } else {
+                        // try to parse as as smart field
+                        for smart_field_match in SMART_FIELDS_RE.captures_iter(&identifier[..]) {
+                            let typed = smart_field_match[2].to_string();
+                            // Default the position to 1 unless there's a matching group for position
+                            let pos = smart_field_match
+                                .get(4)
+                                .map_or(1, |m| m.as_str().parse::<i32>().unwrap_or(1));
+                            // get subfield
+                            let subfield = smart_field_match
+                                .get(6)
+                                .map_or(None, |m| Some(m.as_str().to_string()));
+                            // we use this set to keep track of active smart fields
+                            smart_fields_set.insert(typed.clone());
+                            // track the smartfield
+                            smart_fields.push(SmartColumn {
+                                typed: typed.clone(),
+                                position: pos,
+                                alias: identifier.clone(),
+                                subfield: subfield,
+                            });
+                        }
                     }
-                    // we use this set to keep track of active smart fields
-                    smart_fields_set.insert(typed.clone());
-                    // track the smartfield
-                    smart_fields.push(SmartColumn {
-                        typed: typed.clone(),
-                        position: pos,
-                        alias: identifier.clone(),
-                    });
+                }
+                Expr::CompoundIdentifier(ref identifier) => {
+                    //positional or smart?
+                    let id_name = &identifier[0][1..];
+                    let position = id_name.parse::<i32>().unwrap_or(-1);
+                    // Compounds cannot be positional
+                    if position < 0 {
+                        // try to parse as as smart field
+                        for smart_field_match in SMART_FIELDS_RE.captures_iter(&identifier[0][..]) {
+                            let typed = smart_field_match[2].to_string();
+                            // Default the position to 1 unless there's a matching group for position
+                            let pos = smart_field_match
+                                .get(4)
+                                .map_or(1, |m| m.as_str().parse::<i32>().unwrap_or(1));
+                            // get subfield
+                            let subfield = Some(identifier[1..].join("."));
+                            // we use this set to keep track of active smart fields
+                            smart_fields_set.insert(typed.clone());
+                            // track the smartfield
+                            smart_fields.push(SmartColumn {
+                                typed: typed.clone(),
+                                position: pos,
+                                alias: identifier.join(".").clone(),
+                                subfield: subfield,
+                            });
+                        }
+                    }
+                }
+                ref x => {
+                    info!("Use un unhandled ast {:?}", x);
                 }
             }
         }
@@ -708,40 +788,75 @@ fn process_fields_for_ast(
                     );
                 }
                 _ => {
-                    let identifier = left.to_string();
-
-                    //positional or smart?
-                    let id_name = &identifier[1..];
-                    let position = match id_name.parse::<i32>() {
-                        Ok(p) => p,
-                        Err(_) => -1,
-                    };
-                    // if we were able to parse identifier as an i32 it's a positional
-                    if position > 0 {
-                        positional_fields.push(PositionalColumn {
-                            position: position,
-                            alias: identifier.clone(),
-                        });
-                    } else {
-                        // try to parse as as smart field
-                        for sfield in SMART_FIELDS_RE.captures_iter(&identifier[..]) {
-                            let typed = sfield[2].to_string();
-                            let mut pos = 1;
-                            if sfield.get(4).is_none() == false {
-                                pos = match sfield[4].parse::<i32>() {
-                                    Ok(p) => p,
-                                    // technically this should never happen as the regex already validated an integer
-                                    Err(_) => -1,
-                                };
+                    match **left {
+                        Expr::Identifier(ref identifier) => {
+                            //positional or smart?
+                            let id_name = &identifier[1..];
+                            let position = id_name.parse::<i32>().unwrap_or(-1);
+                            // if we were able to parse identifier as an i32 it's a positional
+                            if position > 0 {
+                                positional_fields.push(PositionalColumn {
+                                    position: position,
+                                    alias: identifier.clone(),
+                                });
+                            } else {
+                                // try to parse as as smart field
+                                for smart_field_match in
+                                    SMART_FIELDS_RE.captures_iter(&identifier[..])
+                                {
+                                    let typed = smart_field_match[2].to_string();
+                                    // Default the position to 1 unless there's a matching group for position
+                                    let pos = smart_field_match
+                                        .get(4)
+                                        .map_or(1, |m| m.as_str().parse::<i32>().unwrap_or(1));
+                                    // get subfield
+                                    let subfield = smart_field_match
+                                        .get(6)
+                                        .map_or(None, |m| Some(m.as_str().to_string()));
+                                    // we use this set to keep track of active smart fields
+                                    smart_fields_set.insert(typed.clone());
+                                    // track the smartfield
+                                    smart_fields.push(SmartColumn {
+                                        typed: typed.clone(),
+                                        position: pos,
+                                        alias: identifier.clone(),
+                                        subfield: subfield,
+                                    });
+                                }
                             }
-                            // we use this set to keep track of active smart fields
-                            smart_fields_set.insert(typed.clone());
-                            // track the smartfield
-                            smart_fields.push(SmartColumn {
-                                typed: typed.clone(),
-                                position: pos,
-                                alias: identifier.clone(),
-                            });
+                        }
+
+                        Expr::CompoundIdentifier(ref identifier) => {
+                            //positional or smart?
+                            let id_name = &identifier[0][1..];
+                            let position = id_name.parse::<i32>().unwrap_or(-1);
+                            // compounds have no positionals
+                            if position < 0 {
+                                // try to parse as as smart field
+                                for smart_field_match in
+                                    SMART_FIELDS_RE.captures_iter(&identifier[0][..])
+                                {
+                                    let typed = smart_field_match[2].to_string();
+                                    // Default the position to 1 unless there's a matching group for position
+                                    let pos = smart_field_match
+                                        .get(4)
+                                        .map_or(1, |m| m.as_str().parse::<i32>().unwrap_or(1));
+                                    // get subfield
+                                    let subfield = Some(identifier[1..].join("."));
+                                    // we use this set to keep track of active smart fields
+                                    smart_fields_set.insert(typed.clone());
+                                    // track the smartfield
+                                    smart_fields.push(SmartColumn {
+                                        typed: typed.clone(),
+                                        position: pos,
+                                        alias: identifier.join(".").clone(),
+                                        subfield: subfield,
+                                    });
+                                }
+                            }
+                        }
+                        ref x => {
+                            info!("Use un unhandled ast {:?}", x);
                         }
                     }
                 }
@@ -762,6 +877,8 @@ pub fn scanlog(text: &String, flags: ScanFlags) -> HashMap<String, Vec<String>> 
         static ref DATE_RE :Regex= Regex::new(r"((19[789]\d|2\d{3})[-/](0[1-9]|1[1-2])[-/](0[1-9]|[1-2][0-9]|3[0-1]*))|((0[1-9]|[1-2][0-9]|3[0-1]*)[-/](Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|(0[1-9]|1[1-2]))[-/](19[789]\d|2\d{3}))").unwrap();
         static ref QUOTED_RE :Regex= Regex::new("((\"(.*?)\")|'(.*?)')").unwrap();
         static ref URL_RE :Regex= Regex::new(r#"(https?|ftp)://[^\s/$.?#].[^()\]\[\s]*"#).unwrap();
+        static ref PHONE_RE :Regex= Regex::new(r#"[\(]?(\d{3})[\)-]?[- ]?(\d{3})[- ]?(\d{4})"#).unwrap();
+        static ref USER_AGENT_RE :Regex= Regex::new(r#""((Mozilla|Links).*? \(.*?\)( .*?[0-9]{1,3}\.[0-9]{1,3}\.?[0-9]{0,3})?)""#).unwrap();
     }
     let mut results: HashMap<String, Vec<String>> = HashMap::new();
 
@@ -805,6 +922,20 @@ pub fn scanlog(text: &String, flags: ScanFlags) -> HashMap<String, Vec<String>> 
         }
         results.insert(SF_URL.to_string(), items);
     }
+    if flags.contains(ScanFlags::PHONE) {
+        let mut items: Vec<String> = Vec::new();
+        for cap in PHONE_RE.captures_iter(text) {
+            items.push(cap[0].to_string())
+        }
+        results.insert(SF_PHONE.to_string(), items);
+    }
+    if flags.contains(ScanFlags::USER_AGENT) {
+        let mut items: Vec<String> = Vec::new();
+        for cap in USER_AGENT_RE.captures_iter(text) {
+            items.push(cap[1].to_string())
+        }
+        results.insert(SF_USER_AGENT.to_string(), items);
+    }
     results
 }
 
@@ -839,10 +970,100 @@ pub fn extract_smart_fields(
                 // if the requested position is available
                 let key = smt.alias.clone();
                 if smt.position - 1 < (found_vals[&smt.typed].len() as i32) {
-                    projection_values.insert(
-                        key,
-                        Some(found_vals[&smt.typed][(smt.position - 1) as usize].clone()),
-                    );
+                    let value = found_vals[&smt.typed][(smt.position - 1) as usize].clone();
+                    // match on subfield usage and validity of the subfield
+                    match (
+                        &smt.typed[..],
+                        &smt.subfield.as_ref().map_or(None, |m| Some(m.as_str())),
+                    ) {
+                        (SF_USER_AGENT, Some("name")) => {
+                            // TODO: Cache this parsing
+                            let parser = woothee::parser::Parser::new();
+                            match parser.parse(&value[..]) {
+                                Some(r) => {
+                                    projection_values.insert(key, Some(r.name.to_string()));
+                                }
+                                None => {
+                                    projection_values.insert(key, None);
+                                }
+                            }
+                        }
+                        (SF_USER_AGENT, Some("category")) => {
+                            // TODO: Cache this parsing
+                            let parser = woothee::parser::Parser::new();
+                            match parser.parse(&value[..]) {
+                                Some(r) => {
+                                    projection_values.insert(key, Some(r.category.to_string()));
+                                }
+                                None => {
+                                    projection_values.insert(key, None);
+                                }
+                            }
+                        }
+                        (SF_USER_AGENT, Some("browser_type")) => {
+                            // TODO: Cache this parsing
+                            let parser = woothee::parser::Parser::new();
+                            match parser.parse(&value[..]) {
+                                Some(r) => {
+                                    projection_values.insert(key, Some(r.browser_type.to_string()));
+                                }
+                                None => {
+                                    projection_values.insert(key, None);
+                                }
+                            }
+                        }
+                        (SF_USER_AGENT, Some("os")) => {
+                            // TODO: Cache this parsing
+                            let parser = woothee::parser::Parser::new();
+                            match parser.parse(&value[..]) {
+                                Some(r) => {
+                                    projection_values.insert(key, Some(r.os.to_string()));
+                                }
+                                None => {
+                                    projection_values.insert(key, None);
+                                }
+                            }
+                        }
+                        (SF_USER_AGENT, Some("os_version")) => {
+                            // TODO: Cache this parsing
+                            let parser = woothee::parser::Parser::new();
+                            match parser.parse(&value[..]) {
+                                Some(r) => {
+                                    projection_values.insert(key, Some(r.os_version.to_string()));
+                                }
+                                None => {
+                                    projection_values.insert(key, None);
+                                }
+                            }
+                        }
+                        (SF_USER_AGENT, Some("version")) => {
+                            // TODO: Cache this parsing
+                            let parser = woothee::parser::Parser::new();
+                            match parser.parse(&value[..]) {
+                                Some(r) => {
+                                    projection_values.insert(key, Some(r.version.to_string()));
+                                }
+                                None => {
+                                    projection_values.insert(key, None);
+                                }
+                            }
+                        }
+                        (SF_USER_AGENT, Some("vendor")) => {
+                            // TODO: Cache this parsing
+                            let parser = woothee::parser::Parser::new();
+                            match parser.parse(&value[..]) {
+                                Some(r) => {
+                                    projection_values.insert(key, Some(r.vendor.to_string()));
+                                }
+                                None => {
+                                    projection_values.insert(key, None);
+                                }
+                            }
+                        }
+                        (_, _) => {
+                            projection_values.insert(key, Some(value));
+                        }
+                    }
                 } else {
                     projection_values.insert(key, None);
                 }
@@ -1177,11 +1398,13 @@ mod query_tests {
                             typed: "$ip".to_string(),
                             position: 1,
                             alias: "$ip".to_string(),
+                            subfield: None,
                         },
                         SmartColumn {
                             typed: "$email".to_string(),
                             position: 1,
                             alias: "$email".to_string(),
+                            subfield: None,
                         }
                     ]
                 );
@@ -1227,11 +1450,13 @@ mod query_tests {
                             typed: "$ip".to_string(),
                             position: 1,
                             alias: "$ip".to_string(),
+                            subfield: None,
                         },
                         SmartColumn {
                             typed: "$email".to_string(),
                             position: 1,
                             alias: "$email".to_string(),
+                            subfield: None,
                         }
                     ]
                 );
@@ -1337,5 +1562,103 @@ mod query_tests {
             None => panic!("Should have reported an error"),
             Some(_) => assert!(true),
         }
+    }
+
+    struct ParseMatchTestCase {
+        log_name: String,
+        query: String,
+        log_line: String,
+        expected: HashMap<String, String>,
+    }
+
+    fn run_parse_and_match_case(tc: ParseMatchTestCase) {
+        let access_token = VALID_TOKEN.to_string();
+
+        let cfg = get_ds_log_auth_config_for(tc.log_name, &access_token);
+        let cfg = Arc::new(RwLock::new(cfg));
+        let query_c = Query::new(cfg);
+
+        let query = tc.query;
+        let ast = query_c.parse_query(query.clone()).unwrap();
+
+        let queries_parse = query_c.process_sql(&access_token, ast).unwrap();
+
+        let log_line = tc.log_line;
+
+        let (the_query, query_data) = match queries_parse.get(0).unwrap() {
+            (x, y) => (x, y),
+        };
+
+        let res = evaluate_query_on_line(&the_query, query_data, log_line);
+
+        let payload = res.unwrap();
+        let res_json: serde_json::Value = serde_json::from_str(&payload).unwrap();
+
+        for (key, value) in tc.expected {
+            if let Some(serde_json::Value::String(res_value)) = res_json.get(key) {
+                assert_eq!(res_value, &value);
+            } else {
+                assert!(false)
+            }
+        }
+    }
+
+    macro_rules! map (
+    { $($key:expr => $value:expr),+ } => {
+        {
+            let mut m = ::std::collections::HashMap::new();
+            $(
+                m.insert($key, $value);
+            )+
+            m
+        }
+     };
+    );
+
+    #[test]
+    fn sf_phone_parse_and_match() {
+        let tc = ParseMatchTestCase {
+            log_name: "mylog".to_string(),
+            query: "SELECT $phone FROM mylog".to_string(),
+            log_line: "xx (555) 555-5555 xx".to_string(),
+            expected: map! {"$phone".to_string() =>"(555) 555-5555".to_string()},
+        };
+        run_parse_and_match_case(tc);
+    }
+
+    #[test]
+    fn sf_email_parse_and_match() {
+        let tc = ParseMatchTestCase {
+            log_name: "mylog".to_string(),
+            query: "SELECT $email FROM mylog".to_string(),
+            log_line: "xx valid@emaildomain.com xx".to_string(),
+            expected: map! {"$email".to_string() =>"valid@emaildomain.com".to_string()},
+        };
+        run_parse_and_match_case(tc);
+    }
+
+    #[test]
+    fn sf_user_agent_parse_and_match() {
+        let tc = ParseMatchTestCase {
+            log_name: "mylog".to_string(),
+            query: "SELECT $user_agent FROM mylog".to_string(),
+            log_line: "xx \"Mozilla/5.0 (Windows NT 10.0; Win64; x64)AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Safari/537.36\" xx".to_string(),
+            expected: map! {"$user_agent".to_string() =>"Mozilla/5.0 (Windows NT 10.0; Win64; x64)AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Safari/537.36".to_string()},
+        };
+        run_parse_and_match_case(tc);
+    }
+
+    #[test]
+    fn scanlog_phone() {
+        let scanflags = ScanFlags::PHONE;
+        let log_line = "xx (555) 555-5555 xx".to_string();
+
+        let mut results = scanlog(&log_line, scanflags);
+
+        assert!(results.contains_key(SF_PHONE));
+        assert_eq!(
+            results.remove(SF_PHONE).unwrap(),
+            vec!["(555) 555-5555".to_string()]
+        );
     }
 }


### PR DESCRIPTION
Adds support for `$phone` and `$user_agent` along with entity properties for `$user_agent`:

* $user_agent.name
* $user_agent.category
* $user_agent.os
* $user_agent.os_version
* $user_agent.browser_type
* $user_agent.version
* $user_agent.vendor	