### PR TITLE
Support for Root Access Key and Secret Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ export MINSQL_METABUCKET_NAME=minsql-meta
 export MINSQL_METABUCKET_ENDPOINT=http://localhost:9000
 export MINSQL_METABUCKET_ACCESS_KEY=minio
 export MINSQL_METABUCKET_SECRET_KEY=minio123
+export MINSQL_ROOT_ACCESS_KEY=minsqlaccesskeyx
+export MINSQL_ROOT_SECRET_KEY=minsqlsecretkeypleasechangexxxx
 ./minsql
 ```
+
+Then go to `http://127.0.0.0.1:9999/ui/` and login with the provided `MINSQL_ROOT_ACCESS_KEY` and  `MINSQL_ROOT_SECRET_KEY`. 
 
 ##### Docker
 Create the compose file
@@ -66,6 +70,8 @@ services:
    MINSQL_METABUCKET_ENDPOINT: http://minio-engine:9000
    MINSQL_ACCESS_KEY: minio
    MINSQL_SECRET_KEY: minio123
+   MINSQL_ROOT_ACCESS_KEY: minsqlaccesskeyx
+   MINSQL_ROOT_SECRET_KEY: minsqlsecretkeypleasechangexxxx
 
 volumes:
   data:
@@ -86,6 +92,8 @@ docker-compose up
 | MINSQL_METABUCKET_SECRET_KEY | Meta Bucket Secret key                            |
 | MINSQL_PKCS12_CERT           | *Optional:* location to a pkcs12 certificate.     |
 | MINSQL_PKCS12_PASSWORD       | *Optional:* password to unlock the certificate.   |
+| MINSQL_ROOT_ACCESS_KEY       | *Optional:* 16 digit access key to bootstrap minsql|
+| MINSQL_ROOT_SECRET_KEY       | *Optional:* 32 digit secret key to bootstrap minsql|
 
 ### Configuring
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,9 @@ services:
    MINSQL_METABUCKET_ENDPOINT: http://minio-engine:9000
    MINSQL_METABUCKET_ACCESS_KEY: minio
    MINSQL_METABUCKET_SECRET_KEY: minio123
+   MINSQL_ROOT_ACCESS_KEY: minsqlaccesskeyx
+   MINSQL_ROOT_SECRET_KEY: minsqlsecretkeypleasechangexxxx
+   RUST_LOG: info
 
 volumes:
   data:

--- a/src/api/tokens.rs
+++ b/src/api/tokens.rs
@@ -193,17 +193,12 @@ impl ApiTokens {
 impl ViewSet for ApiTokens {
     fn list(&self, req: Request<Body>) -> ResponseFuture {
         let cfg_read = self.config.read().unwrap();
-        let mut tokens: Vec<Token> = Vec::new();
-        let mut tokens = cfg_read 
-                   .tokens
-                   .values()
-                   .filter(|token| token.api_access)
-                   .map(|token| token.clone()) 
-                   .collect::<Vec<Token>>();
-            if token.api_access {
-                tokens.push(token.clone());
-            }
-        }
+        let mut tokens = cfg_read
+            .tokens
+            .values()
+            .filter(|token| token.api_access)
+            .map(|token| token.clone())
+            .collect::<Vec<Token>>();
         // sort
         tokens.sort_by(|a, b| a.access_key.cmp(&b.access_key));
         // paginate

--- a/src/api/tokens.rs
+++ b/src/api/tokens.rs
@@ -194,7 +194,12 @@ impl ViewSet for ApiTokens {
     fn list(&self, req: Request<Body>) -> ResponseFuture {
         let cfg_read = self.config.read().unwrap();
         let mut tokens: Vec<Token> = Vec::new();
-        for (_, token) in &cfg_read.tokens {
+        let mut tokens = cfg_read 
+                   .tokens
+                   .values()
+                   .filter(|token| token.api_access)
+                   .map(|token| token.clone()) 
+                   .collect::<Vec<Token>>();
             if token.api_access {
                 tokens.push(token.clone());
             }

--- a/src/api/tokens.rs
+++ b/src/api/tokens.rs
@@ -62,6 +62,7 @@ impl ApiTokens {
             description: None,
             is_admin: false,
             enabled: true,
+            api_access: false,
         };
 
         let token: serde_json::Value = match serde_json::from_str(&payload) {
@@ -194,7 +195,9 @@ impl ViewSet for ApiTokens {
         let cfg_read = self.config.read().unwrap();
         let mut tokens: Vec<Token> = Vec::new();
         for (_, token) in &cfg_read.tokens {
-            tokens.push(token.clone());
+            if token.api_access {
+                tokens.push(token.clone());
+            }
         }
         // sort
         tokens.sort_by(|a, b| a.access_key.cmp(&b.access_key));

--- a/src/config.rs
+++ b/src/config.rs
@@ -267,7 +267,7 @@ pub fn load_configuration() -> Result<Config, ConfigurationError> {
         Err(_) => None,
     };
     // if both are provided
-    if root_username.is_none() == false && root_password.is_none() == false {
+    if root_username.is_some() && root_password.is_some() {
         configuration.tokens.insert(
             root_username.clone().unwrap(),
             Token {

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,11 +18,11 @@ use std::collections::HashMap;
 use std::env;
 use std::fmt;
 
+use clap::{App, Arg};
 use log::error;
 use serde_derive::{Deserialize, Serialize};
 
 use crate::constants::DEFAULT_SERVER_ADDRESS;
-use clap::{App, Arg};
 
 // environment variables
 pub const METABUCKET_ENDPOINT: &str = "MINSQL_METABUCKET_ENDPOINT";
@@ -31,6 +31,8 @@ pub const METABUCKET_ACCESS_KEY: &str = "MINSQL_METABUCKET_ACCESS_KEY";
 pub const METABUCKET_SECRET_KEY: &str = "MINSQL_METABUCKET_SECRET_KEY";
 pub const PKCS12_CERT: &str = "MINSQL_PKCS12_CERT";
 pub const PKCS12_PASSWORD: &str = "MINSQL_PKCS12_PASSWORD";
+pub const ROOT_ACCESS_KEY: &str = "MINSQL_ROOT_ACCESS_KEY";
+pub const ROOT_SECRET_KEY: &str = "MINSQL_ROOT_SECRET_KEY";
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Config {
@@ -77,6 +79,7 @@ pub struct Log {
 fn def_true() -> bool {
     true
 }
+
 fn def_false() -> bool {
     false
 }
@@ -90,6 +93,8 @@ pub struct Token {
     pub is_admin: bool,
     #[serde(default = "def_true")]
     pub enabled: bool,
+    #[serde(default = "def_true")]
+    pub api_access: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -251,6 +256,30 @@ pub fn load_configuration() -> Result<Config, ConfigurationError> {
     };
 
     let mut configuration = Config::new(server);
+
+    // if a root username and password were provided, add them to the list of valid accesskey
+    let root_username: Option<String> = match env::var(ROOT_ACCESS_KEY) {
+        Ok(val) => Some(val),
+        Err(_) => None,
+    };
+    let root_password: Option<String> = match env::var(ROOT_SECRET_KEY) {
+        Ok(val) => Some(val),
+        Err(_) => None,
+    };
+    // if both are provided
+    if root_username.is_none() == false && root_password.is_none() == false {
+        configuration.tokens.insert(
+            root_username.clone().unwrap(),
+            Token {
+                access_key: root_username.clone().unwrap(),
+                secret_key: root_password.clone().unwrap(),
+                is_admin: true,
+                enabled: true,
+                description: None,
+                api_access: false,
+            },
+        );
+    }
 
     // store datasource names in the structs
     for (name, ds) in &mut configuration.datastore {

--- a/src/http.rs
+++ b/src/http.rs
@@ -317,6 +317,7 @@ mod http_tests {
                 description: None,
                 is_admin: false,
                 enabled: true,
+                api_access: false,
             },
         );
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -1205,6 +1205,7 @@ mod query_tests {
                 description: None,
                 is_admin: false,
                 enabled: true,
+                api_access: false,
             },
         );
 


### PR DESCRIPTION
This access support for `MINSQL_ROOT_ACCESS_KEY` and `MINSQL_ROOT_SECRET_KEY` so that new minsql instances can gain access to the API and UI to setup their own accounts.

This key pair is not listed on the Auth APIs